### PR TITLE
Fixed build issue that was caused by not having both the 2.9 and 3.0 versions of wxWidgets installed

### DIFF
--- a/wxc/Setup.hs
+++ b/wxc/Setup.hs
@@ -242,7 +242,9 @@ readWxConfig = do
     wxVersions <- case buildOS of
       Windows -> sequence [readProcess "wx-config" ["--release"] ""]
       _       -> mapM readVersion wxAcceptableVersions
-                 where readVersion x = readProcess "wx-config" ["--version=" ++ x, "--version-full"] ""
+                 where readVersion x = E.catch (readProcess "wx-config" ["--version=" ++ x, "--version-full"] "") handleError
+                       handleError :: IOError -> IO String
+                       handleError _ = return ""
 
     case [(x, y) | x <- wxAcceptableVersions, 
                    y <- wxVersions, 


### PR DESCRIPTION
`wx-config` returns an error that wasn't being caught when passed a `--version=*` flag specifying a version of wxWidgets that has not been installed.

This patch wraps the call to `wx-config` and returns an empty string on failure so that it will be appropriately discarded by the `isPrefixOf` function.

This was tested on Ubuntu 14.04 with only the `libwxgtk3.0-dev` and `libwxgtk-media3.0-dev` wxWidgets packages installed.
