### PR TITLE
Update glcanvas.cpp

### DIFF
--- a/wxc/src/cpp/glcanvas.cpp
+++ b/wxc/src/cpp/glcanvas.cpp
@@ -16,6 +16,7 @@
 
 #ifndef wxUSE_GLCANVAS
 # define wxGLCanvas      void
+# define wxGLContext     void
 #endif
 
 extern "C" {


### PR DESCRIPTION
Missing wxGLContext define. Without this define, wxc will not compile when OpenGL is not available (wxUSE_GLCANVAS not being defined). See: wx/glcanvas.h where its declared below the #if wxUSE_GLCANVAS.
