### PR TITLE
Adding Windows MSYS2 support for wxHaskell

### DIFF
--- a/wxc/Setup.hs
+++ b/wxc/Setup.hs
@@ -294,9 +294,11 @@ readWxConfig =
           putStrLn ("Configuring wxc to build against wxWidgets " ++ wxVersion)
 
           -- The Windows port of wx-config doesn't let you specify a version (yet)
-          case buildOS of
+          isMsys <- isWindowsMsys
+          case (buildOS,isMsys) of
             -- wx-config-win does not list all libraries if --cppflags comes after --libs :-(
-            Windows -> wx_config ["--cppflags", "--libs", "all"]
+            (Windows,False) -> wx_config ["--cppflags", "--libs", "all"]
+            (Windows,True) -> wx_config ["--libs", "all", "--gl-libs", "--cppflags"]
             _       -> wx_config ["--version=" ++ wxVersion, "--libs", "all", "--cppflags"]
 
 


### PR DESCRIPTION
Hi I have modified the Setup.hs for wxc and wxdirect in order to support an MSYS2 environment on Windows. I found this is for me the easiest way to get wxHaskell to install on Windows, I have tried previously and failed.

My build environment for Haskell is essentially set-up according to the following instructions https://ghc.haskell.org/trac/ghc/wiki/Building/Preparation/Windows and http://sourceforge.net/p/msys2/wiki/MSYS2%20installation/ . Using MSYS2 you have a Linux like build environment. 

Using MSYS2 on Windows 7 you can get wxHaskell installed easily doing the following:
* Download the source for wxWidgets and extract to a folder (https://www.wxwidgets.org/downloads/)
* Open MSYS2 shell and cd to the directory where wxWidgets was extracted
* type: autoconf
* type: ./configure --enable-monolithic --disable-debug --disable-debug_flag --with-msw --build=i386-pc-mingw32 --with-opengl
* type: make install
* If you have the modified wxHaskell as a source
    * type: cabal install wx
* The DLLs needed to run on my system were 
    * WXC.dll - found in the dist/build directory of wxc
    * wxMsw30U_GCC_Custom.dll - found in /c/usr/local/lib or MYSYS2_Install_Dir\usr\local\lib
    * wxMsw30U_gl_GCC_Custom.dll - found in /c/usr/local/lib or MYSYS2_Install_Dir\usr\local\lib
    * LIBSTDC++-6.DLL - found in GHC_Install_Dir\mingw\bin\
    * LIBGCC_S_DW2-1.DLL  - found in GHC_Install_Dir\mingw\bin\

I am about 80% sure I didn't break it for the normal Windows case nor for the other build environments.

