### PR TITLE
Bump required base version to >= 4.6

### DIFF
--- a/wxc/wxc.cabal
+++ b/wxc/wxc.cabal
@@ -159,7 +159,7 @@ library
     wxc_types.h
 
   build-depends:
-    base >= 4 && < 5,
+    base >= 4.6 && < 5,
     wxdirect >= 0.90.1.1
 
   x-dll-sources:


### PR DESCRIPTION
Setup.hs uses System.Environment.lookupEnv, which was only introduced in base-4.6.