### PR TITLE
GHCi fixes for Windows

### DIFF
--- a/wxc/src/cpp/ewxw_main.cpp
+++ b/wxc/src/cpp/ewxw_main.cpp
@@ -46,7 +46,17 @@ EWXWEXPORT(void, ELJApp_InitializeC) (wxClosure* closure, int _argc, char** _arg
 
   initClosure = closure;
   APPTerminating = 0;
-  wxEntry(wxhInstance, NULL, (_argc > 0 ? _argv[0] : NULL), SW_SHOWNORMAL);
+  
+  /* Pretty lame way to detect if we are running in GHCI */
+  /* TODO: detect when running program with runhaskell as well */
+  if(_argc > 0 && !wcscmp(((wchar_t**)_argv)[0], L"<interactive>")) {
+    /* we are in GHCI */
+    wxEntry(_argc, _argv);
+  }
+  else {
+    wxEntry(wxhInstance, NULL, (_argc > 0 ? _argv[0] : NULL), SW_SHOWNORMAL);
+  }
+  
   APPTerminating = 1;
 
   /* wxPendingEvents is deleted but not set to NULL -> disaster when restarted from an interpreter */


### PR DESCRIPTION
This set of changes make wxHaskell work in GHCi on Windows.
Tested on Windows 8.1 32-bit.