### PR TITLE
Fix build for *BSD

### DIFF
--- a/wxc/Setup.hs
+++ b/wxc/Setup.hs
@@ -23,7 +23,7 @@ import Distribution.Simple.Utils (installOrdinaryFile, rawSystemExitWithEnv, raw
 import Distribution.System (OS (..), Arch (..), buildOS, buildArch)
 import Distribution.Verbosity (Verbosity, normal, verbose)
 import Distribution.Compat.Exception (catchIO)
-import System.Process (system)
+import System.Process (system, readProcess)
 import System.Directory ( createDirectoryIfMissing, doesFileExist
                         , findExecutable,           getCurrentDirectory
                         , getDirectoryContents,     getModificationTime
@@ -41,14 +41,6 @@ import Control.Monad (unless)
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
 -- Some utility functions
-
-readProcess :: FilePath -> [String] -> String -> IO String
-readProcess cmd args stdin =
-  Process.readProcess cmd args stdin
-  `E.catch` \(E.SomeException err) -> do
-    hPutStrLn stderr $ "readProcess failed: " ++ show err
-    E.throwIO err
-
 
 whenM :: Monad m => m Bool -> m () -> m ()
 whenM mp e = mp >>= \p -> when p e

--- a/wxc/Setup.hs
+++ b/wxc/Setup.hs
@@ -1,7 +1,7 @@
 
 {-# LANGUAGE CPP #-}
 
-import Control.Monad (filterM, join, mapM_, when)
+import Control.Monad (filterM, join, mapM_, when, liftM2)
 import qualified Data.ByteString.Lazy as B
 import Data.Char     ( ord )
 import Data.Functor  ( (<$>) )

--- a/wxc/Setup.hs
+++ b/wxc/Setup.hs
@@ -337,7 +337,7 @@ readWxConfig wxVersion =
     putStrLn ("Configuring wxc to build against wxWidgets " ++ wxVersion)
     
     -- find GL/glx.h on non-Linux systems
-      let glIncludeDirs = readProcess "pkg-config" ["--cflags", "gl"] "" `E.onException` return ""
+    let glIncludeDirs = readProcess "pkg-config" ["--cflags", "gl"] "" `E.onException` return ""
     
     -- The Windows port of wx-config doesn't let you specify a version (yet)
     isMsys <- isWindowsMsys

--- a/wxcore/Setup.hs
+++ b/wxcore/Setup.hs
@@ -3,7 +3,7 @@ import Control.Monad (when, filterM)
 import Data.List (foldl', intersperse, intercalate, nub, lookup, isPrefixOf, isInfixOf, find)
 import Data.Maybe (fromJust)
 import Distribution.PackageDescription hiding (includeDirs)
-import Distribution.PackageDescription as PD (includeDirs)
+import qualified Distribution.PackageDescription as PD (includeDirs)
 import Distribution.InstalledPackageInfo(installedPackageId, sourcePackageId, includeDirs)
 import Distribution.Simple
 import Distribution.Simple.LocalBuildInfo (LocalBuildInfo, localPkgDescr, installedPkgs, withPrograms, buildDir)


### PR DESCRIPTION
Build was previously broken on FreeBSD, NetBSD.
Slightly better now. Still missing stuff.

summary:
- ldconfig is Linux-only (especially hard coded path /sbin/ldconfig).
- GL/glx.h needs to be included, it is not a problem in Linux because it is in /usr/include.
in non-Linux it is in a place like /usr/X11R7/include.
I searched for it using pkg-config.
- removed definition of readProcess, it already exists in System.Process.