### PR TITLE
Prevent wx cmdline args handling

### DIFF
--- a/wxc/src/cpp/wrapper.cpp
+++ b/wxc/src/cpp/wrapper.cpp
@@ -2,6 +2,7 @@
 #include "wx/tooltip.h"
 #include "wx/dynlib.h"
 #include "wx/fs_zip.h"
+#include "wx/cmdline.h"
 
 /* quantize is not supported on wxGTK 2.4.0 */
 #if !defined(__WXGTK__) || (wxVERSION_NUMBER > 2400)
@@ -104,6 +105,18 @@ void ELJApp::HandleEvent(wxEvent& _evt)
   else if (callback) {
     callback->Invoke( &_evt );  /* normal: invoke the callback function */
   }
+}
+
+/* override to prevent parent wxApp failing to parse Haskell cmdline args */
+void ELJApp::OnInitCmdLine(wxCmdLineParser& parser)
+{
+  parser.SetCmdLine("");
+}
+
+/* override to prevent parent wxApp from further processing of parsed cmdline */
+bool ELJApp::OnCmdLineParsed(wxCmdLineParser& parser)
+{
+  return true;
 }
 
 /*-----------------------------------------------------------------------------

--- a/wxc/src/include/wrapper.h
+++ b/wxc/src/include/wrapper.h
@@ -151,6 +151,8 @@ class ELJApp: public wxApp
     void HandleEvent(wxEvent& _evt);
     void InitZipFileSystem();
     void InitImageHandlers();
+    void OnInitCmdLine(wxCmdLineParser& parser);
+    bool OnCmdLineParsed(wxCmdLineParser& parser);
 };
 
 


### PR DESCRIPTION
This is a fix for the ticket I created at https://sourceforge.net/p/wxhaskell/bugs/105/ and is based somewhat on advice from the related ticket at http://trac.wxwidgets.org/ticket/16935

The wx cmdline parsing itself is troublesome, and I guess pretty undesirable outside of C++ clients anyway, so I have scrubbed the cmdline args instead of trying to ignore parsing errors.