### PR TITLE
Fix invalid type casting

### DIFF
--- a/wxc/src/cpp/eljipc.cpp
+++ b/wxc/src/cpp/eljipc.cpp
@@ -25,7 +25,7 @@ EWXWEXPORT(bool,ELJConnection_Execute)(ELJConnection* self,wxString* data,int si
 	
 EWXWEXPORT(void*,ELJConnection_Request)(void* self,wxString* item,void* size,int format)
 {
-	return (void*)((ELJConnection*)self)->Request(*item, (int*)size, (wxIPCFormat)format);
+	return (void*)((ELJConnection*)self)->Request(*item, (size_t*)size, (wxIPCFormat)format);
 }
 	
 EWXWEXPORT(bool,ELJConnection_Poke)(ELJConnection* self,wxString* item,wxChar* data,int size,int format)


### PR DESCRIPTION
wxc in wxHaskell cannot build on Xcode/MacOSX with default compile options. It throws an error.
There is a mismatch invalid type casting in .h and .cpp.

    wxHaskell/wxc/src/cpp/eljipc.cpp:28:55: error: cannot initialize a parameter of type 'size_t *' (aka 'unsigned long *') with an rvalue of type 'int *'
            return (void*)((ELJConnection*)self)->Request(*item, (int*)size, (wxIPCFormat)format);
                                                                 ^~~~~~~~~~

OS: Mac OS X 10.11.3 Beta (15D9c)
IDE: Xcode Version 7.2 (7C68)
Compiler: Clang Apple LLVM version 7.0.2 (clang-700.1.81)