### PR TITLE
Fix toWXDate of IsDate Day instance.

### DIFF
--- a/wx/src/Graphics/UI/WX/Controls.hs
+++ b/wx/src/Graphics/UI/WX/Controls.hs
@@ -487,7 +487,7 @@ instance IsDate Day where
   -- time zone??
   toWXDate utc = do
     wxd <- dateTimeCreate
-    dateTimeSet wxd (fromInteger y) (m - 1) d 0 0 0 0
+    dateTimeSet wxd d (m - 1) (fromInteger y) 0 0 0 0
     return wxd
     where (y,m,d) = toGregorian utc
   fromWXDate wxd = fromGregorian


### PR DESCRIPTION
According to [WxWidgets documentation](http://wxpython.org/docs/api/wx.DateTime-class.html#Set), the Set method of DateTime accepts the date in day, month, year order. The IsDate Day instance reverses this order which makes WxWidgets throw an exception upon setting a valid date.