### PR TITLE
Support Cabal 2.0

### DIFF
--- a/wxc/Setup.hs
+++ b/wxc/Setup.hs
@@ -502,7 +502,7 @@ sharedLibName ver basename =
       OSX     -> "lib" ++ addExtension basename ".dylib"
       _       -> "lib" ++ basename ++ ".so." ++ full_ver
         where
-          full_ver = (concat . intersperse "." . map show . versionBranch) ver
+          full_ver = showVersion ver
 
 -- | Return any linker options required to support shared library creation
 linkCxxOpts :: Version  -- ^ Version information to be used for Unix shared libraries

--- a/wxc/wxc.cabal
+++ b/wxc/wxc.cabal
@@ -307,7 +307,7 @@ library
 custom-setup
   setup-depends: 
     base, 
-    Cabal < 2,
+    Cabal < 2.1,
     bytestring,
     split,
     process,


### PR DESCRIPTION
This allows us to avoid pulling it old versions of libs, such as
process 1.4