### PR TITLE
Make wxc work with stack ghci/intero out of the box

### DIFF
--- a/wxc/Setup.hs
+++ b/wxc/Setup.hs
@@ -31,7 +31,7 @@ import System.Directory ( createDirectoryIfMissing, doesFileExist
                         )
 import System.Environment (lookupEnv, getEnvironment)
 import System.Exit (ExitCode (..), exitFailure)
-import System.FilePath ((</>), (<.>), replaceExtension, takeFileName, dropFileName, addExtension)
+import System.FilePath ((</>), (<.>), replaceExtension, takeFileName, dropFileName, addExtension, takeDirectory)
 import System.IO (hPutStrLn, readFile, stderr)
 import System.IO.Error (isDoesNotExistError)
 import System.IO.Unsafe (unsafePerformIO)
@@ -606,7 +606,7 @@ linkingNeeded output input =
 -- | The 'normalise' implementation in System.FilePath does not meet the requirements of
 -- calling and/or running external programs on Windows particularly well as it does not
 -- normalise the '/' character to '\\'. The problem is that some MinGW programs do not
--- like to see paths with a mixture of '/' and '\\'. Sine we are calling out to these,
+-- like to see paths with a mixture of '/' and '\\'. Since we are calling out to these,
 -- we require a stricter normalisation.
 normalisePath :: FilePath -> FilePath
 normalisePath = case buildOS of
@@ -627,7 +627,7 @@ dosifyFilePath = replace '/' '\\'
 
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
--- | Run ldconfig in `path` and return a list of all the links which were created
+-- | Run ldconfig in `path`, creating an appropriate `.so` file
 ldconfig :: FilePath -> IO ()
 ldconfig path = case buildOS of
     Windows -> return ()
@@ -638,6 +638,21 @@ ldconfig path = case buildOS of
             case ld_exit_code of
                 ExitSuccess -> return ()
                 otherwise -> error "Couldn't execute ldconfig, ensure it is on your path"
+
+-- | Create an additional symlink for Stack GHCi to work properly. See Github PR #33.
+mkSymlink :: FilePath -> IO ()
+mkSymlink path = case buildOS of
+    Windows -> return ()
+    OSX     -> return ()
+    _       ->
+          do
+            ln_exit_code <- system ("ln -sf " ++ target ++ " " ++ link_name)
+            case ln_exit_code of
+                ExitSuccess -> return ()
+                otherwise -> error "Couldn't execute ln, ensure that it is on your path."
+          where
+            target = path </> "libwxc.so"
+            link_name = takeDirectory path </> "libwxc.so"
 
 myCopyHook :: PackageDescription -> LocalBuildInfo -> UserHooks -> CopyFlags -> IO ()
 myCopyHook = hookHelper (fromFlag . copyVerbosity) (fromFlagOrDefault NoCopyDest . copyDest) (copyHook simpleUserHooks)
@@ -669,3 +684,4 @@ hookHelper verbosity copydest origHook pkg_descr local_bld_info user_hooks flags
 
     installOrdinaryFile (verbosity flags) (bld_dir </> lib_name) (inst_lib_dir </> lib_name)
     ldconfig inst_lib_dir
+    mkSymlink inst_lib_dir


### PR DESCRIPTION
Actually this PR is not 100% complete as I'm not sure how the problem should be solved. But I do have a minimal example kinda' running.

Trying to use `intero` along with `wx` and friends which has been slightly troublesome for me. As discussed on the Stack Issue Tracker (https://github.com/commercialhaskell/stack/issues/2299), the problem is that Stack expects the two files to be one directory up, along with the other `.so` files.

> I just copied the two files (`libwxc.so` -- this appears to be a relative symlink -- and `libwxc.so.0.92.3.0`) from the folder `.stack-work/install/x86_64-linux-nopie/lts-9.10/8.0.2/lib/wxc-0.92.3.0-7rSQ...1eo4` to one level up, at the same place as the `libHSwx-0.92.3.0-KU6F...T55hz-ghc8.0.2.so` file. This makes Intero work fine for me.

Currently, this PR just adds a line that creates an additional copy of `libwxc.so.0.93.0.0` one directory up. Ideally, what we should do is just create an additional symlink from one directory up (and not a copy of the actual library itself), but I have no clue what code is responsible for creating the symlink. In the same place, I can add a line that creates an additional symlink. Where should I look for this?

A toy project for this PR can be found here: https://github.com/theindigamer/wxhs-test

It includes lightly modified versions `wxHaskell` (changes from this PR) and `reactive-banana` (bumped version of `reactive-banana-wx`'s dependencies) as submodules for convenience. Commands for easy copy-paste:

```
git clone https://github.com/theindigamer/wxhs-test.git
cd wxhs-test
stack build
cd .stack-work/install/x86_64-linux-nopie/nightly-2017-11-20/8.2.1/lib/x86_64-linux-ghc-8.2.1/
cp wxc-0.93.0.0-G9YTZGyIBwiDmBTeV4gbzR/libwxc.so ./
cd ../../../../../../../
```