### PR TITLE
Bug fix for Ambiguous occurrence `CBool`

### DIFF
--- a/wxcore/src/haskell/Graphics/UI/WXCore/WxcTypes.hs
+++ b/wxcore/src/haskell/Graphics/UI/WXCore/WxcTypes.hs
@@ -123,7 +123,7 @@ module Graphics.UI.WXCore.WxcTypes(
 
 import Control.Exception 
 import Data.Ix
-import Foreign.C
+import Foreign.C hiding (CBool)
 import Foreign.Ptr
 import Foreign.Storable
 import Foreign.Marshal.Alloc


### PR DESCRIPTION
Ref: https://stackoverflow.com/questions/47677841/install-wxhaskell-64-on-windows-10-get-error-foreign-import-ccall-booltoint-c